### PR TITLE
Changing the active style to be controlled by a class

### DIFF
--- a/src/lib/components/GridItem.react.js
+++ b/src/lib/components/GridItem.react.js
@@ -1,0 +1,82 @@
+import React, { Component, useEffect } from "react"
+
+class GridItem extends Component {
+
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            active: false
+        }
+
+        this.activate = this.activate.bind(this);
+        this.deactivate = this.deactivate.bind(this);
+    }
+
+    activate() {
+        this.setState(prev => {
+            let newState = { ...prev };
+            newState.active = true;
+            return newState;
+        })
+    }
+
+    deactivate() {
+        this.setState(prev => {
+            let newState = { ...prev };
+            newState.active = false;
+            return newState;
+        })
+    }
+
+    render() {
+        const props = this.props;
+        let activeClass = "";
+        if (this.state.active || this.props.active) {
+            activeClass = "active";
+        }
+
+        return (
+            <div
+                key={props.key}
+                data-grid={props.data_grid}
+                style={{ ...props.style }}
+                className={[props.className, activeClass].join(" ")}
+                ref={props.innerRef}
+                onMouseDown={props.onMouseDown}
+                onMouseUp={props.onMouseUp}
+                onTouchEnd={props.onTouchEnd}
+            >
+                <div className="item-top-container">
+                    <div className="item-top"
+                        onMouseDown={() => this.activate()}
+                        onMouseUp={() => this.deactivate()}
+                    >...</div>
+                    <button
+                        className="close-button"
+                        onClick={() => props.onCloseClicked && props.onCloseClicked()}
+                    >
+                        &times;
+                    </button>
+                </div>
+
+                <div
+                    className="item-content"
+                    onMouseDown={(e) => e.stopPropagation()}
+                >
+                    {props.children}
+                </div>
+            </div>
+        );
+    }
+}
+
+export default React.forwardRef((props, ref) => {
+    return (
+        <GridItem
+            innerRef={ref} {...props}
+        >
+            {props.children}
+        </GridItem>
+    );
+})

--- a/src/lib/components/ToolBoxGrid.react.js
+++ b/src/lib/components/ToolBoxGrid.react.js
@@ -20,6 +20,7 @@ import {Toolbox} from './Toolbox.react.js';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import './style.css';
+import GridItem from './GridItem.react.js';
 
 /**
  * ToolBoxGrid is an addition to the ResponsiveGridLayout
@@ -87,8 +88,11 @@ export default class ToolBoxGrid extends Component {
             setProps: this.props.setProps,
             onDropHeight: this.props.onDropHeight,
             onDropWidth: this.props.onDropWidth,
-            classNames: {}
+            activeWindows: {}
         };
+
+        this.handleResizeStart = this.handleResizeStart.bind(this);
+        this.handleResizeStop = this.handleResizeStop.bind(this);
     }
 
     handleDrop = (layout, layoutItem, _event) => {
@@ -206,6 +210,22 @@ export default class ToolBoxGrid extends Component {
             };
         },
         () => {});
+    }
+
+    handleResizeStart(layout, oldItem, newItem, placeholder, e, element) {
+        this.setState(prev => {
+            let newState = {...prev};
+            newState.activeWindows[oldItem.i] = true;
+            return newState;
+        })
+    }
+
+    handleResizeStop(layout, oldItem, newItem, placeholder, e, element) {
+        this.setState(prev => {
+            let newState = {...prev};
+            newState.activeWindows[oldItem.i] = false;
+            return newState;
+        })
     }
 
     componentDidMount() {
@@ -342,22 +362,6 @@ export default class ToolBoxGrid extends Component {
         }));
     }
 
-    makeItemActive(key) {
-        this.setState(prev => {
-            let newState = {...prev};
-            newState.classNames[key] = 'active';
-            return newState;
-        })
-    }
-
-    makeItemInactive(key) {
-        this.setState(prev => {
-            let newState = {...prev};
-            newState.classNames[key] = '';
-            return newState;
-        })
-    }
-
     render() {
         let {children = []} = this.props;
         const {
@@ -398,6 +402,8 @@ export default class ToolBoxGrid extends Component {
                     rowHeight={height}
                     onDrop={this.handleDrop}
                     onLayoutChange={this.handleLayoutChange}
+                    onResizeStart={this.handleResizeStart}
+                    onResizeStop={this.handleResizeStop}
                     {...this.props}
                 >
                     {gridContent.map((child, key) => {
@@ -433,32 +439,13 @@ export default class ToolBoxGrid extends Component {
                         }
 
                         return (
-                            <div
+                            <GridItem
                                 key={_key}
-                                className={"item " + (this.state.classNames[_key] || "")}
+                                className={"item"}
                                 data-grid={_data_grid}
-                            >
-                                {
-                                    <div className="item-top-container">
-                                        <div className="item-top"
-                                            onMouseDown={() => this.makeItemActive(_key)}
-                                            onMouseUp={() => this.makeItemInactive(_key)}
-                                        >...</div>
-                                        <button
-                                            className="close-button"
-                                            onClick={() => this.onPutItem(_key)}
-                                        >
-                                            &times;
-                                        </button>
-                                    </div>
-                                }
-                                <div
-                                    className="item-content"
-                                    onMouseDown={(e) => e.stopPropagation()}
-                                >
-                                    {child}
-                                </div>
-                            </div>
+                                onCloseClicked={() => this.onPutItem(_key)}
+                                active={this.state.activeWindows[_key] || false}
+                            >{child}</GridItem>
                         );
                     })}
                 </ResponsiveReactGridLayout>

--- a/src/lib/components/ToolBoxGrid.react.js
+++ b/src/lib/components/ToolBoxGrid.react.js
@@ -87,10 +87,11 @@ export default class ToolBoxGrid extends Component {
             setProps: this.props.setProps,
             onDropHeight: this.props.onDropHeight,
             onDropWidth: this.props.onDropWidth,
+            classNames: {}
         };
     }
 
-    onDrop = (layout, layoutItem, _event) => {
+    handleDrop = (layout, layoutItem, _event) => {
         _event.persist();
 
         this.setState((prevState) => {
@@ -146,7 +147,7 @@ export default class ToolBoxGrid extends Component {
 
     /* We need to caputre the changes in break point to find it for the right toolbox. it will enable us to store different 
     configurations for sizes */
-    onBreakpointChange = (breakpoint) => {
+    handleBreakpointChange = (breakpoint) => {
         this.setState((prevState) => {
             return {
                 currentBreakpoint: breakpoint,
@@ -161,7 +162,7 @@ export default class ToolBoxGrid extends Component {
         });
     };
 
-    onLayoutChange = (current_layout, all_layouts) => {
+    handleLayoutChange = (current_layout, all_layouts) => {
         // First we save the layout to the local storage
         if (this.state.save) {
             all_layouts = appendInToolboxFalse(all_layouts);
@@ -205,7 +206,7 @@ export default class ToolBoxGrid extends Component {
             };
         },
         () => {});
-    };
+    }
 
     componentDidMount() {
         let {children = []} = this.props;
@@ -229,7 +230,7 @@ export default class ToolBoxGrid extends Component {
         // Build layout on inital start
         //   Priority to client local store [except if specified]
         //   Then layout
-        //   And then DashboardItem [except if sepcified])
+        //   And then DashboardItem [except if specified])
         if (clearSavedLayout) {
             saveToLs(`${id}-layouts`, null);
         }
@@ -341,6 +342,22 @@ export default class ToolBoxGrid extends Component {
         }));
     }
 
+    makeItemActive(key) {
+        this.setState(prev => {
+            let newState = {...prev};
+            newState.classNames[key] = 'active';
+            return newState;
+        })
+    }
+
+    makeItemInactive(key) {
+        this.setState(prev => {
+            let newState = {...prev};
+            newState.classNames[key] = '';
+            return newState;
+        })
+    }
+
     render() {
         let {children = []} = this.props;
         const {
@@ -376,11 +393,11 @@ export default class ToolBoxGrid extends Component {
                     style={style}
                     layouts={this.state.layouts}
                     cols={gridCols}
-                    onBreakpointChange={this.onBreakpointChange}
+                    onBreakpointChange={this.handleBreakpointChange}
                     breakpoints={breakpoints}
                     rowHeight={height}
-                    onDrop={this.onDrop}
-                    onLayoutChange={this.onLayoutChange}
+                    onDrop={this.handleDrop}
+                    onLayoutChange={this.handleLayoutChange}
                     {...this.props}
                 >
                     {gridContent.map((child, key) => {
@@ -414,21 +431,22 @@ export default class ToolBoxGrid extends Component {
                         } else {
                             _key = key.toString();
                         }
+
                         return (
                             <div
                                 key={_key}
-                                className="item"
+                                className={"item " + (this.state.classNames[_key] || "")}
                                 data-grid={_data_grid}
                             >
                                 {
                                     <div className="item-top-container">
-                                        <span className="item-top">...</span>
+                                        <div className="item-top"
+                                            onMouseDown={() => this.makeItemActive(_key)}
+                                            onMouseUp={() => this.makeItemInactive(_key)}
+                                        >...</div>
                                         <button
                                             className="close-button"
-                                            onClick={this.onPutItem.bind(
-                                                this,
-                                                _key
-                                            )}
+                                            onClick={() => this.onPutItem(_key)}
                                         >
                                             &times;
                                         </button>

--- a/src/lib/components/style.css
+++ b/src/lib/components/style.css
@@ -10,7 +10,12 @@
     box-shadow: 0px 1px 10px -1px rgba(30, 44, 57, 0.15);
     /* box-shadow: 0px 10px 25px -2px rgba(30, 44, 57, 0.15); */
 }
-.item:active {
+/* .item:active {
+    box-shadow: 0px 25px 25px -2px rgba(30, 44, 57, 0.15);
+    transition: box-shadow 200ms;
+} */
+
+.item.active {
     box-shadow: 0px 25px 25px -2px rgba(30, 44, 57, 0.15);
     transition: box-shadow 200ms;
 }

--- a/src/lib/components/style.css
+++ b/src/lib/components/style.css
@@ -18,6 +18,7 @@
 .item.active {
     box-shadow: 0px 25px 25px -2px rgba(30, 44, 57, 0.15);
     transition: box-shadow 200ms;
+    border: 1px solid blue;
 }
 
 .toolbox {


### PR DESCRIPTION
The psuedoclass :active isn't affected (prevented) by event handlers or propagation. I've changed it to instead use react rendering and mouse event handlers to apply a separate class when there is a click down on the top bar. This might need a little more refining, but principally it seems to resolve the issue.