### PR TITLE
Build and publish to PyPi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
-        pip install wheel
+        pip install --upgrade pip setuptools wheel
         pip install -r requirements.txt
         npm install
     - name: Build package

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+        pip install wheel
         pip install -r requirements.txt
         npm install
     - name: Build package

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,6 +25,11 @@ jobs:
         
     steps:
     - uses: actions/checkout@v3
+
+    - name: Version NPM Package
+      run: |
+        find . -name "*" -exec sed -i "s/__VERSION__/${{ github.ref_name }}/g" {}
+    
     - name: Set up Python
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,18 +26,20 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Version NPM Package
+    - name: Versioning (${{ github.ref_name }})
       run: |
-        find . -name "*" -exec sed -i "s/__VERSION__/${{ github.ref_name }}/g" {}
+        find . -name "*" -exec sed -i "s/__VERSION__/${{ github.ref_name }}/g" {} +
     
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
         python-version: '3.x'
+        
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+        
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -45,10 +47,12 @@ jobs:
         pip install --upgrade pip setuptools wheel
         pip install -r requirements.txt
         npm install
+        
     - name: Build package
       run: |
         npm run build
         python -m build
+        
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Build package
       run: |
         npm run build
-        python setup.py sdist bdist_wheel
+        python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Versioning (${{ github.ref_name }})
       run: |
-        find . -name "*" -exec sed -i "s/__VERSION__/${{ github.ref_name }}/g" {} +
+        find . -type f -exec sed -i "s/__VERSION__/${{ github.ref_name }}/g" {} +
     
     - name: Set up Python
       uses: actions/setup-python@v3

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,50 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+        
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+        pip install -r requirements.txt
+        npm install
+    - name: Build package
+      run: |
+        npm run build
+        python setup.py sdist bdist_wheel
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@
 name = "DashDragGrid"
 uuid = "1b08a953-4be3-4667-9a23-4015cbeafbd6"
 authors = ["Simon Unterbusch <simonunterbusch@unterbusch.com>"]
-version = "0.9.4"
+version = "__VERSION__"
 
 [deps]
 Dash = "1b08a953-4be3-4667-9a23-3db579824955"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash_drag_grid",
-  "version": "0.9.4",
+  "version": "__VERSION__",
   "description": "Draggable Toolbox grid based on react grid",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This GitHub Actions workflow is designed to automatically build and publish your project to PyPI each time a release is created on GitHub. It utilizes the tag name of the release as the version number. To enable this functionality, ensure that the PyPI API token is added to your GitHub repository's secrets under the key **PYPI_API_TOKEN**.

## Workflow Overview:
**Tagging and Releases:** When you create a release in GitHub, a corresponding tag is also created. This workflow assumes that the tag follows semantic versioning, which is required for compatibility with PyPI.

## Version Number Format:
**Standard Format:** The recommended format for version numbers is **[N!]N(.N)*[{a|b|rc}N][.postN][.devN]**. Examples of valid formats include:
**Stable Releases:** 0.0.0
**Pre-releases:** 0.0.0a1 (where 'a' denotes an alpha release)
Using these formats ensures that the versioning is recognized correctly by PyPI and helps maintain a consistent release strategy.